### PR TITLE
minor code change for scrollToBegining()

### DIFF
--- a/GeniusLyrics.js
+++ b/GeniusLyrics.js
@@ -1513,7 +1513,6 @@ Genius:     ${originalUrl}
 
   async function scrollToBegining () {
     await new Promise(resolve => setTimeout(resolve, 100))
-
     let selector = null
     const isContentStylesIsAdded = !!document.querySelector('style#egl-contentstyles')
     if (isContentStylesIsAdded) {
@@ -3600,11 +3599,15 @@ Link__StyledLink
           clear() // loaded
           spinnerUpdate(null, null, 901, 'complete')
           window.postMessage({ iAm: custom.scriptName, type: 'lyricsDisplayState', visibility: 'loaded', lyricsSuccess: true }, '*')
+          unScroll()
+          setTimeout(() => {
+            // delay required due to scrollToBegining() is changing the scrollTop
+            window.isPageAbleForAutoScroll = true
+          }, 240)
         })
         addOneMessageListener('iframeContentRendered', function (ev) {
           if (window.showLyricsIdentifier !== currentFunctionClosureIdentifier) return
           unScroll()
-          window.isPageAbleForAutoScroll = true
         })
 
         function reloadFrame () {

--- a/GeniusLyrics.js
+++ b/GeniusLyrics.js
@@ -1514,20 +1514,24 @@ Genius:     ${originalUrl}
   async function scrollToBegining () {
     await new Promise(resolve => setTimeout(resolve, 100))
 
-    let selector = theme.scrollableContainer
+    let selector = null
+    const isContentStylesIsAdded = !!document.querySelector('style#egl-contentstyles')
+    if (isContentStylesIsAdded) {
+      selector = 'html #application'
+      theme.scrollableContainer = selector
+      theme.scrollLyrics = scrollLyricsFunction(selector, 0)
+    } else {
+      selector = theme.scrollableContainer
+    }
     let scrollable = document.querySelector(selector)
     if (isScrollLyricsEnabled()) {
-      if (document.querySelector('style#egl-contentstyles')) {
-        selector = 'html #application'
-        theme.scrollableContainer = selector
-        theme.scrollLyrics = scrollLyricsFunction(selector, 0)
-        scrollable = document.querySelector(selector)
-      }
-      scrollable.scrollIntoView()
-    } else if (scrollable && scrollable.firstElementChild) {
-      window.scrollTo(0, scrollable.firstElementChild.getBoundingClientRect().top)
+      scrollable.scrollIntoView(true) // alignToTop = true
     } else if (scrollable) {
-      scrollable.scrollIntoView()
+      const innerTopElement = isContentStylesIsAdded
+        ? scrollable.querySelector('.genius-lyrics-header-content')
+        : scrollable.firstElementChild
+      scrollable = (innerTopElement || scrollable)
+      scrollable.scrollIntoView(true) // alignToTop = true
     }
   }
 

--- a/GeniusLyrics.js
+++ b/GeniusLyrics.js
@@ -1258,6 +1258,12 @@ Genius:     ${originalUrl}
   html.v {
     visibility: visible;
   }
+  html .genius-scrollable{
+    scroll-behavior: smooth;
+  }
+  html.instant-scroll .genius-scrollable{
+    scroll-behavior: auto;
+  }
   #resumeAutoScrollButtonContainer{
     position: fixed; 
     right: 20px; 
@@ -1512,6 +1518,7 @@ Genius:     ${originalUrl}
   }
 
   async function scrollToBegining () {
+    document.documentElement.classList.add('instant-scroll')
     await new Promise(resolve => setTimeout(resolve, 100))
     let selector = null
     const isContentStylesIsAdded = !!document.querySelector('style#egl-contentstyles')
@@ -1524,14 +1531,21 @@ Genius:     ${originalUrl}
     }
     let scrollable = document.querySelector(selector)
     if (isScrollLyricsEnabled()) {
-      scrollable.scrollIntoView(true) // alignToTop = true
+      // scrollable.scrollIntoView(true)
     } else if (scrollable) {
       const innerTopElement = isContentStylesIsAdded
         ? scrollable.querySelector('.genius-lyrics-header-content')
         : scrollable.firstElementChild
       scrollable = (innerTopElement || scrollable)
-      scrollable.scrollIntoView(true) // alignToTop = true
+      // scrollable.scrollIntoView(true)
+    } else {
+      return
     }
+    scrollable.classList.add('genius-scrollable')
+    await Promise.resolve(0) // allow CSS rule changed
+    scrollable.scrollIntoView(true) // alignToTop = true
+    await Promise.resolve(0) // allow DOM scrollTop changed
+    document.documentElement.classList.remove('instant-scroll')
   }
 
   const themes = {


### PR DESCRIPTION
the traditional `scrollTo` method is not reliable since `offsetTop` computation is complicated and usually wrong for modern complex layout structure.

use `scrollIntoView` instead.

However using `scrollIntoView` will not instantly scroll to the desired position. It is because `scroll-behavior: smooth` is set by default.
`scroll-behavior: auto` shall temporarily set by CSS. (avoid using `scrollIntoViewOptions`)

after the `scrollTop` is ready, allow the main window to call `scrollLyrics`. This is done by `setTimeout` delay
before that, the content will be still visible just autoscroll is not yet ready